### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ pytest>=3.0.5
 gevent>=1.2.1
 msgpack-python>=0.4.8
 populus
-bbc1
 


### PR DESCRIPTION
'bbc1' in requirements.txt cause conflict. 
venv/lib/python3.6/site-packages/bbc1  <==> git cloned bbc1